### PR TITLE
Feature/optimize resolution storage

### DIFF
--- a/flash_flow.yml.erb.example
+++ b/flash_flow.yml.erb.example
@@ -75,7 +75,7 @@ branch_info_file: 'your/random/file'
 
 #branches:
 #  class:
-#    name: 'FlashFlow::Branch::Github'
+#    name: 'FlashFlow::Data::Github'
 #    token: <%= ENV['GH_TOKEN'] %>
 #    repo: # Your github repo. For example, the flash_flow repo is 'flashfunders/flash_flow'
 #    master_branch: master

--- a/lib/flash_flow/branch.rb
+++ b/lib/flash_flow/branch.rb
@@ -1,8 +1,0 @@
-require 'flash_flow/branch/base'
-require 'flash_flow/branch/collection'
-require 'flash_flow/branch/store'
-
-module FlashFlow
-  module Branch
-  end
-end

--- a/lib/flash_flow/branch_merger.rb
+++ b/lib/flash_flow/branch_merger.rb
@@ -1,7 +1,7 @@
 module FlashFlow
   class BranchMerger
 
-    attr_reader :conflict_sha
+    attr_reader :conflict_sha, :resolutions
 
     def initialize(git, branch)
       @git = git
@@ -33,7 +33,7 @@ module FlashFlow
         @git.run('rerere forget')
         false
       else
-        @git.rerere_resolve!
+        @resolutions = @git.rerere_resolve!
       end
     end
 

--- a/lib/flash_flow/data.rb
+++ b/lib/flash_flow/data.rb
@@ -1,0 +1,8 @@
+require 'flash_flow/data/branch'
+require 'flash_flow/data/collection'
+require 'flash_flow/data/store'
+
+module FlashFlow
+  module Data
+  end
+end

--- a/lib/flash_flow/data.rb
+++ b/lib/flash_flow/data.rb
@@ -1,6 +1,4 @@
-require 'flash_flow/data/branch'
-require 'flash_flow/data/collection'
-require 'flash_flow/data/store'
+require 'flash_flow/data/base'
 
 module FlashFlow
   module Data

--- a/lib/flash_flow/data/base.rb
+++ b/lib/flash_flow/data/base.rb
@@ -8,8 +8,6 @@ module FlashFlow
     class Base
       extend Forwardable
 
-      attr_accessor :deleted_resolutions
-
       def_delegators :@collection, :add_story, :mergeable, :mark_deleted, :mark_success,
                      :mark_failure, :remove_from_merge, :add_to_merge, :failures, :set_resolutions
 
@@ -30,8 +28,7 @@ module FlashFlow
 
       def to_hash
         {
-            'branches' => merged_branches,
-            'deleted_resolutions' => deleted_resolutions
+            'branches' => merged_branches.to_hash
         }
       end
 

--- a/lib/flash_flow/data/base.rb
+++ b/lib/flash_flow/data/base.rb
@@ -27,9 +27,7 @@ module FlashFlow
       end
 
       def to_hash
-        {
-            'branches' => merged_branches.to_hash
-        }
+        merged_branches.to_hash
       end
 
       def merged_branches

--- a/lib/flash_flow/data/base.rb
+++ b/lib/flash_flow/data/base.rb
@@ -1,0 +1,55 @@
+require 'json'
+require 'flash_flow/data/branch'
+require 'flash_flow/data/collection'
+require 'flash_flow/data/store'
+
+module FlashFlow
+  module Data
+    class Base
+      extend Forwardable
+
+      attr_accessor :deleted_resolutions
+
+      def_delegators :@collection, :add_story, :mergeable, :mark_deleted, :mark_success,
+                     :mark_failure, :remove_from_merge, :add_to_merge, :failures
+
+      def initialize(branch_config, filename, git, opts={})
+        @git = git
+        @store = Store.new(filename, git, opts)
+        @collection = initialize_collection(branch_config, git.remotes_hash)
+      end
+
+      def initialize_collection(branch_config, remotes)
+        Collection.fetch(remotes, branch_config) ||
+            Collection.from_hash(remotes, backwards_compatible_store['branches'])
+      end
+
+      def save!
+        @store.write(to_hash)
+      end
+
+      def to_hash
+        {
+            'branches' => merged_branches,
+            'deleted_resolutions' => deleted_resolutions
+        }
+      end
+
+      def merged_branches
+        @collection.reverse_merge(Collection.from_hash({}, backwards_compatible_store['branches']))
+      end
+
+      def backwards_compatible_store
+        @backwards_compatible_store ||= begin
+          hash = @store.get
+          hash.has_key?('branches') ? hash : { 'branches' => hash }
+        end
+      end
+
+      def saved_branches
+        Collection.from_hash(@git.remotes, backwards_compatible_store['branches']).to_a
+      end
+
+    end
+  end
+end

--- a/lib/flash_flow/data/base.rb
+++ b/lib/flash_flow/data/base.rb
@@ -11,7 +11,7 @@ module FlashFlow
       attr_accessor :deleted_resolutions
 
       def_delegators :@collection, :add_story, :mergeable, :mark_deleted, :mark_success,
-                     :mark_failure, :remove_from_merge, :add_to_merge, :failures
+                     :mark_failure, :remove_from_merge, :add_to_merge, :failures, :set_resolutions
 
       def initialize(branch_config, filename, git, opts={})
         @git = git

--- a/lib/flash_flow/data/branch.rb
+++ b/lib/flash_flow/data/branch.rb
@@ -4,26 +4,28 @@ module FlashFlow
   module Data
 
     class Branch
-      attr_accessor :remote, :remote_url, :ref, :sha, :status, :stories, :metadata, :updated_at, :created_at
+      attr_accessor :remote, :remote_url, :ref, :sha, :status, :resolutions, :stories, :metadata, :updated_at, :created_at
 
       def initialize(_remote, _remote_url, _ref)
         @remote = _remote
         @remote_url = _remote_url
         @ref = _ref
+        @resolutions = {}
         @stories = []
         @updated_at = Time.now
         @created_at = Time.now
       end
 
       def self.from_hash(hash)
-        base = new(hash['remote'], hash['remote_url'], hash['ref'])
-        base.sha = hash['sha']
-        base.status = hash['status']
-        base.stories = hash['stories']
-        base.metadata = hash['metadata']
-        base.updated_at = massage_time(hash['updated_at'])
-        base.created_at = massage_time(hash['created_at'])
-        base
+        branch = new(hash['remote'], hash['remote_url'], hash['ref'])
+        branch.sha = hash['sha']
+        branch.status = hash['status']
+        branch.resolutions = hash['resolutions']
+        branch.stories = hash['stories']
+        branch.metadata = hash['metadata']
+        branch.updated_at = massage_time(hash['updated_at'])
+        branch.created_at = massage_time(hash['created_at'])
+        branch
       end
 
       def self.massage_time(time)
@@ -48,6 +50,7 @@ module FlashFlow
             'ref' => ref,
             'sha' => sha,
             'status' => status,
+            'resolutions' => resolutions,
             'stories' => stories,
             'metadata' => metadata,
             'updated_at' => updated_at,
@@ -63,6 +66,7 @@ module FlashFlow
         unless other.nil?
           self.sha = other.sha
           self.status = other.status
+          self.resolutions = other.resolutions
           self.stories = self.stories.to_a | other.stories.to_a
           self.updated_at = Time.now
           self.created_at = [(self.created_at || Time.now), (other.created_at || Time.now)].min
@@ -74,6 +78,10 @@ module FlashFlow
       def add_metadata(data)
         self.metadata ||= {}
         self.metadata.merge!(data)
+      end
+
+      def set_resolutions(_resolutions)
+        self.resolutions = _resolutions
       end
 
       def success!

--- a/lib/flash_flow/data/branch.rb
+++ b/lib/flash_flow/data/branch.rb
@@ -1,9 +1,9 @@
 require 'json'
 
 module FlashFlow
-  module Branch
+  module Data
 
-    class Base
+    class Branch
       attr_accessor :remote, :remote_url, :ref, :sha, :status, :stories, :metadata, :updated_at, :created_at
 
       def initialize(_remote, _remote_url, _ref)

--- a/lib/flash_flow/data/branch.rb
+++ b/lib/flash_flow/data/branch.rb
@@ -57,6 +57,7 @@ module FlashFlow
             'created_at' => created_at,
         }
       end
+      alias :to_h :to_hash
 
       def to_json(_)
         JSON.pretty_generate(to_hash)

--- a/lib/flash_flow/data/collection.rb
+++ b/lib/flash_flow/data/collection.rb
@@ -47,6 +47,7 @@ module FlashFlow
           end
         end
       end
+      alias :to_h :to_hash
 
       def reverse_merge(old)
         merged_branches = @branches.dup
@@ -56,17 +57,20 @@ module FlashFlow
           info.created_at ||= Time.now
         end
 
-        old.each do |full_ref, info|
+        old.branches.each do |full_ref, info|
           if merged_branches.has_key?(full_ref)
-            merged_branches[full_ref].created_at = info.created_at
-            merged_branches[full_ref].stories = info.stories.to_a | merged_branches[full_ref].stories.to_a
+            branch = merged_branches[full_ref]
+
+            branch.created_at = info.created_at
+            branch.resolutions = branch.resolutions.to_h.merge(info.resolutions.to_h)
+            branch.stories = info.stories.to_a | merged_branches[full_ref].stories.to_a
           else
             merged_branches[full_ref] = info
             merged_branches[full_ref].status = nil
           end
         end
 
-        merged_branches
+        self.class.from_hash(remotes, merged_branches)
       end
 
       def to_a

--- a/lib/flash_flow/data/collection.rb
+++ b/lib/flash_flow/data/collection.rb
@@ -136,6 +136,13 @@ module FlashFlow
         branch
       end
 
+      def set_resolutions(branch, resolutions)
+        update_or_add(branch)
+        branch.set_resolutions(resolutions)
+        @collection_instance.set_resolutions(branch) if @collection_instance.respond_to?(:set_resolutions)
+        branch
+      end
+
       private
 
       def key(remote_url, ref)

--- a/lib/flash_flow/data/collection.rb
+++ b/lib/flash_flow/data/collection.rb
@@ -1,8 +1,8 @@
-require 'flash_flow/branch/base'
-require 'flash_flow/branch/github'
+require 'flash_flow/data/branch'
+require 'flash_flow/data/github'
 
 module FlashFlow
-  module Branch
+  module Data
 
     class Collection
 
@@ -145,7 +145,7 @@ module FlashFlow
       end
 
       def record(remote, remote_url, ref)
-        update_or_add(Branch::Base.new(remote, remote_url, ref))
+        update_or_add(Branch.new(remote, remote_url, ref))
       end
 
     end

--- a/lib/flash_flow/data/github.rb
+++ b/lib/flash_flow/data/github.rb
@@ -1,8 +1,8 @@
 require 'octokit'
-require 'flash_flow/branch/base'
+require 'flash_flow/data/branch'
 
 module FlashFlow
-  module Branch
+  module Data
     class Github
 
       attr_accessor :repo, :unmergeable_label
@@ -33,7 +33,7 @@ module FlashFlow
 
       def fetch
         pull_requests.map do |pr|
-          Base.from_hash(
+          Branch.from_hash(
               'remote_url' => pr.head.repo.ssh_url,
               'ref' => pr.head.ref,
               'status' => status_from_labels(pr),

--- a/lib/flash_flow/data/store.rb
+++ b/lib/flash_flow/data/store.rb
@@ -10,42 +10,9 @@ module FlashFlow
         @logger = opts[:logger] || Logger.new('/dev/null')
       end
 
-      def merge(old, new)
-        merged_branches = new.dup
-
-        merged_branches.each do |_, info|
-          info.updated_at = Time.now
-          info.created_at ||= Time.now
-        end
-
-        old.each do |full_ref, info|
-          if merged_branches.has_key?(full_ref)
-            merged_branches[full_ref].created_at = info.created_at
-            merged_branches[full_ref].stories = info.stories.to_a | merged_branches[full_ref].stories.to_a
-          else
-            merged_branches[full_ref] = info
-            merged_branches[full_ref].status = nil
-          end
-        end
-
-        merged_branches
-      end
-
-      def merge_and_save(new_branches)
-        write(merge(get, new_branches))
-      end
-
-      def fetch
-        get.values
-      end
-
       def get
         file_contents = @git.read_file_from_merge_branch(@filename)
-        hash = JSON.parse(file_contents)
-        hash.each do |key, val|
-          hash[key] = Branch.from_hash(val)
-        end
-        hash
+        JSON.parse(file_contents)
 
       rescue JSON::ParserError, Errno::ENOENT
         @logger.error "Unable to read branch info from file: #{@filename}"

--- a/lib/flash_flow/data/store.rb
+++ b/lib/flash_flow/data/store.rb
@@ -20,7 +20,7 @@ module FlashFlow
       end
 
       def write(branches, file=nil)
-        @git.in_merge_branch do
+        @git.in_temp_merge_branch do
           file ||= File.open(@filename, 'w')
           file.puts JSON.pretty_generate(branches)
           file.close

--- a/lib/flash_flow/data/store.rb
+++ b/lib/flash_flow/data/store.rb
@@ -1,8 +1,8 @@
 require 'json'
-require 'flash_flow/branch'
+require 'flash_flow/data'
 
 module FlashFlow
-  module Branch
+  module Data
     class Store
       def initialize(filename, git, opts={})
         @filename = filename
@@ -43,7 +43,7 @@ module FlashFlow
         file_contents = @git.read_file_from_merge_branch(@filename)
         hash = JSON.parse(file_contents)
         hash.each do |key, val|
-          hash[key] = Base.from_hash(val)
+          hash[key] = Branch.from_hash(val)
         end
         hash
 

--- a/lib/flash_flow/deploy.rb
+++ b/lib/flash_flow/deploy.rb
@@ -97,6 +97,7 @@ module FlashFlow
         when :success
           branch.sha = merger.sha
           @data.mark_success(branch)
+          @data.set_resolutions(branch, merger.resolutions)
 
         when :conflict
           @data.mark_failure(branch, merger.conflict_sha)

--- a/lib/flash_flow/deploy.rb
+++ b/lib/flash_flow/deploy.rb
@@ -41,22 +41,25 @@ module FlashFlow
         @lock.with_lock do
           open_pull_request
 
-          @git.reset_merge_branch
-          @git.in_merge_branch do
+          @git.reset_temp_merge_branch
+          @git.in_temp_merge_branch do
             merge_branches
             commit_branch_info
             commit_rerere
           end
 
+          @git.copy_temp_to_merge_branch
+          @git.delete_temp_merge_branch
           @git.push_merge_branch
         end
 
         print_errors
         logger.info "### Finished #{@git.merge_branch} merge ###"
       rescue Lock::Error, OutOfSyncWithRemote => e
-        @git.run("checkout #{@git.working_branch}")
         puts 'Failure!'
         puts e.message
+      ensure
+        @git.run("checkout #{@git.working_branch}")
       end
     end
 

--- a/lib/flash_flow/deploy.rb
+++ b/lib/flash_flow/deploy.rb
@@ -1,7 +1,7 @@
 require 'logger'
 
 require 'flash_flow/git'
-require 'flash_flow/branch'
+require 'flash_flow/data'
 require 'flash_flow/lock'
 require 'flash_flow/notifier'
 require 'flash_flow/branch_merger'
@@ -20,8 +20,8 @@ module FlashFlow
       @git = Git.new(Config.configuration.git, logger)
       @lock = Lock::Base.new(Config.configuration.lock)
       @notifier = Notifier::Base.new(Config.configuration.notifier)
-      store = Branch::Store.new(Config.configuration.branch_info_file, @git, logger: logger)
-      @branches = Branch::Collection.fetch(@git.remotes_hash, store, Config.configuration.branches)
+      store = Data::Store.new(Config.configuration.branch_info_file, @git, logger: logger)
+      @branches = Data::Collection.fetch(@git.remotes_hash, store, Config.configuration.branches)
     end
 
     def logger

--- a/lib/flash_flow/deploy.rb
+++ b/lib/flash_flow/deploy.rb
@@ -45,7 +45,7 @@ module FlashFlow
           @git.in_merge_branch do
             merge_branches
             commit_branch_info
-            @git.commit_rerere
+            commit_rerere
           end
 
           @git.push_merge_branch
@@ -71,6 +71,17 @@ module FlashFlow
         @data.add_story(@git.merge_remote, @git.working_branch, story_id)
       end
       @data.save!
+    end
+
+    def commit_rerere
+      current_branches = @data.merged_branches.to_a.select { |branch| !@git.master_branch_contains?(branch.sha) && (Time.now - branch.updated_at < two_weeks) }
+      current_rereres = current_branches.map { |branch| branch.resolutions.to_h.values }.flatten
+
+      @git.commit_rerere(current_rereres)
+    end
+
+    def two_weeks
+      60 * 60 * 24 * 14
     end
 
     def merge_branches

--- a/lib/flash_flow/git.rb
+++ b/lib/flash_flow/git.rb
@@ -174,11 +174,11 @@ module FlashFlow
       run("show -s --format=%cd head")
     end
 
-    def reset_merge_branch
+    def reset_temp_merge_branch
       in_branch(master_branch) do
         run("fetch #{merge_remote}")
-        run("branch -D #{merge_branch}")
-        run("checkout -b #{merge_branch}")
+        run("branch -D #{temp_merge_branch}")
+        run("checkout -b #{temp_merge_branch}")
         run("reset --hard #{merge_remote}/#{master_branch}")
       end
     end
@@ -187,11 +187,46 @@ module FlashFlow
       run("push -f #{merge_remote} #{merge_branch}")
     end
 
+    def copy_temp_to_merge_branch
+      run("checkout #{temp_merge_branch}")
+      run("merge --strategy=ours --no-edit #{merge_branch}")
+      run("checkout #{merge_branch}")
+      run("merge #{temp_merge_branch}")
+
+      run("log #{merge_remote}/#{merge_branch}..#{merge_branch}~3")
+      log = last_stdout
+      run("diff --name-only #{merge_remote}/#{merge_branch} #{merge_branch}")
+      files = last_stdout.split("\n")
+      run("reset #{merge_remote}/#{merge_branch}")
+      run("add #{files.join(" ")}")
+      run("commit -m '#{commit_message(log)}'")
+      # require 'byebug'; debugger
+      # puts 'hello'
+    end
+
+    def commit_message(log)
+      "Flash Flow run from branch: #{working_branch}\n\n#{log}"
+    end
+
+    def delete_temp_merge_branch
+      in_merge_branch do
+        run("branch -d #{temp_merge_branch}")
+      end
+    end
+
+    def in_temp_merge_branch(&block)
+      in_branch(temp_merge_branch, &block)
+    end
+
     def in_merge_branch(&block)
       in_branch(merge_branch, &block)
     end
 
     private
+
+    def temp_merge_branch
+      "flash_flow/#{merge_branch}"
+    end
 
     def in_branch(branch)
       begin

--- a/lib/flash_flow/git.rb
+++ b/lib/flash_flow/git.rb
@@ -84,10 +84,14 @@ module FlashFlow
       @cmd_runner.run('cp -R rr-cache/* .git/rr-cache/')
     end
 
-    def commit_rerere
+    def commit_rerere(current_rereres)
       return unless use_rerere
       @cmd_runner.run('mkdir rr-cache')
-      @cmd_runner.run('cp -R .git/rr-cache/* rr-cache/')
+      @cmd_runner.run('rm -rf rr-cache/*')
+      current_rereres.each do |rerere|
+        @cmd_runner.run("cp -R .git/rr-cache/#{rerere} rr-cache/")
+      end
+
       run('add rr-cache/')
       run("commit -m 'Update rr-cache'")
     end

--- a/lib/flash_flow/issue_tracker.rb
+++ b/lib/flash_flow/issue_tracker.rb
@@ -39,9 +39,9 @@ module FlashFlow
       end
 
       def get_branches
-        branch_info_store = Data::Store.new(Config.configuration.branch_info_file, git, logger: Config.configuration.logger)
+        branch_info_store = Data::Base.new(Config.configuration.branches, Config.configuration.branch_info_file, git, logger: Config.configuration.logger)
 
-        branch_info_store.get
+        branch_info_store.saved_branches
       end
 
       def issue_tracker

--- a/lib/flash_flow/issue_tracker.rb
+++ b/lib/flash_flow/issue_tracker.rb
@@ -1,8 +1,8 @@
 require 'logger'
 
 require 'flash_flow/git'
-require 'flash_flow/branch'
-require 'flash_flow/branch/store'
+require 'flash_flow/data'
+require 'flash_flow/data/store'
 require 'flash_flow/issue_tracker/pivotal'
 
 module FlashFlow
@@ -39,7 +39,7 @@ module FlashFlow
       end
 
       def get_branches
-        branch_info_store = Branch::Store.new(Config.configuration.branch_info_file, git, logger: Config.configuration.logger)
+        branch_info_store = Data::Store.new(Config.configuration.branch_info_file, git, logger: Config.configuration.logger)
 
         branch_info_store.get
       end

--- a/lib/flash_flow/issue_tracker/pivotal.rb
+++ b/lib/flash_flow/issue_tracker/pivotal.rb
@@ -19,20 +19,19 @@ module FlashFlow
 
       def stories_pushed
         if merged_working_branch
-          branch = merged_working_branch.last
-          branch.stories.to_a.each do |story_id|
+          merged_working_branch.stories.to_a.each do |story_id|
             finish(story_id)
           end
         end
       end
 
       def stories_delivered
-        merged_branches.each do |_, branch|
+        merged_branches.each do |branch|
           branch.stories.to_a.each do |story_id|
             deliver(story_id)
           end
         end
-        removed_branches.each do |_, branch|
+        removed_branches.each do |branch|
           branch.stories.to_a.each do |story_id|
             undeliver(story_id)
           end
@@ -40,7 +39,7 @@ module FlashFlow
       end
 
       def production_deploy
-        shipped_branches.each do |_, branch|
+        shipped_branches.each do |branch|
           branch.stories.to_a.each do |story_id|
             comment(story_id)
           end
@@ -141,19 +140,19 @@ module FlashFlow
       end
 
       def shipped_branches
-        @branches.select { |_, b| shipped?(b) }
+        @branches.select { |b| shipped?(b) }
       end
 
       def merged_branches
-        @branches.select { |_, v| v.success? }
+        @branches.select { |b| b.success? }
       end
 
       def removed_branches
-        @branches.select { |_, v| v.removed? }
+        @branches.select { |b| b.removed? }
       end
 
       def merged_working_branch
-        merged_branches.detect { |_, branch| branch.ref == @git.working_branch }
+        merged_branches.detect { |b| b.ref == @git.working_branch }
       end
 
     end

--- a/lib/flash_flow/notifier.rb
+++ b/lib/flash_flow/notifier.rb
@@ -1,4 +1,4 @@
-require 'flash_flow/branch'
+require 'flash_flow/data'
 require 'flash_flow/notifier/hipchat'
 
 module FlashFlow

--- a/test/lib/data/test_base.rb
+++ b/test/lib/data/test_base.rb
@@ -1,0 +1,10 @@
+require 'minitest_helper'
+require 'flash_flow/data/store'
+
+module FlashFlow
+  module Data
+    class TestBase < Minitest::Test
+      # Embarrassingly lazy. Write some tests.
+    end
+  end
+end

--- a/test/lib/data/test_branch.rb
+++ b/test/lib/data/test_branch.rb
@@ -1,18 +1,18 @@
 require 'minitest_helper'
-require 'flash_flow/branch/store'
+require 'flash_flow/data/store'
 
 module FlashFlow
-  module Branch
-    class TestBase < Minitest::Test
+  module Data
+    class TestBranch < Minitest::Test
 
       def test_merge_returns_self_if_other_is_nil
-        branch = Base.from_hash(branch_hash)
+        branch = Branch.from_hash(branch_hash)
         assert_equal(branch.merge(nil), branch)
       end
 
       def test_merge_keeps_the_oldest_created_at
-        new_branch = Base.from_hash(branch_hash)
-        old_branch = Base.from_hash(branch_hash)
+        new_branch = Branch.from_hash(branch_hash)
+        old_branch = Branch.from_hash(branch_hash)
         old_branch.created_at -= 1000
 
         assert_equal(new_branch.merge(old_branch).created_at, old_branch.created_at)
@@ -20,8 +20,8 @@ module FlashFlow
       end
 
       def test_merge_handles_nil_stories
-        new_branch = Base.from_hash(branch_hash)
-        old_branch = Base.from_hash(branch_hash)
+        new_branch = Branch.from_hash(branch_hash)
+        old_branch = Branch.from_hash(branch_hash)
 
         new_branch.stories = nil
         old_branch.stories = ['456', '789']
@@ -31,8 +31,8 @@ module FlashFlow
       end
 
       def test_merge_unions_the_stories
-        new_branch = Base.from_hash(branch_hash)
-        old_branch = Base.from_hash(branch_hash)
+        new_branch = Branch.from_hash(branch_hash)
+        old_branch = Branch.from_hash(branch_hash)
 
         new_branch.stories = ['123', '456']
         old_branch.stories = ['456', '789']
@@ -41,8 +41,8 @@ module FlashFlow
       end
 
       def test_merge_uses_other_status
-        new_branch = Base.from_hash(branch_hash)
-        old_branch = Base.from_hash(branch_hash)
+        new_branch = Branch.from_hash(branch_hash)
+        old_branch = Branch.from_hash(branch_hash)
 
         old_branch.success!
         new_branch.fail!
@@ -53,8 +53,8 @@ module FlashFlow
       end
 
       def test_merge_sets_updated_at
-        new_branch = Base.from_hash(branch_hash)
-        old_branch = Base.from_hash(branch_hash)
+        new_branch = Branch.from_hash(branch_hash)
+        old_branch = Branch.from_hash(branch_hash)
 
         original_updated_at = new_branch.updated_at
 
@@ -62,8 +62,8 @@ module FlashFlow
       end
 
       def test_merge_sets_created_at_if_not_set
-        new_branch = Base.from_hash(branch_hash)
-        old_branch = Base.from_hash(branch_hash)
+        new_branch = Branch.from_hash(branch_hash)
+        old_branch = Branch.from_hash(branch_hash)
 
         new_branch.created_at = old_branch.created_at = nil
 
@@ -71,7 +71,7 @@ module FlashFlow
       end
 
       def test_from_hash
-        branch = Base.from_hash(branch_hash)
+        branch = Branch.from_hash(branch_hash)
         assert_equal(branch.ref, branch_hash['ref'])
         assert_equal(branch.remote_url, branch_hash['remote_url'])
         assert_equal(branch.remote, branch_hash['remote'])
@@ -83,7 +83,7 @@ module FlashFlow
       def test_from_hash_with_time_objects
         branch_hash['updated_at'] = Time.now - 200
         branch_hash['created_at'] = Time.now - 200
-        branch = Base.from_hash(branch_hash)
+        branch = Branch.from_hash(branch_hash)
         assert_equal(branch.updated_at, branch_hash['updated_at'])
         assert_equal(branch.created_at, branch_hash['created_at'])
       end
@@ -92,7 +92,7 @@ module FlashFlow
         time = Time.parse('2015-05-22 09:47:07 -0700')
         branch_hash['updated_at'] = branch_hash['created_at'] = nil
         Time.stub(:now, time) do
-          branch = Base.from_hash(branch_hash)
+          branch = Branch.from_hash(branch_hash)
 
           assert_equal(branch.updated_at, time)
           assert_equal(branch.created_at, time)
@@ -103,14 +103,14 @@ module FlashFlow
         time = Time.parse('2015-05-22 09:47:07 -0700')
         branch_hash['updated_at'] = '2015-05-22 09:47:07 -0700'
         branch_hash['created_at'] = '2015-05-22 09:47:07 -0700'
-        branch = Base.from_hash(branch_hash)
+        branch = Branch.from_hash(branch_hash)
         assert_equal(branch.updated_at, time)
         assert_equal(branch.created_at, time)
       end
 
       def test_double_equals
-        branch1 = Base.from_hash(branch_hash)
-        branch2 = Base.from_hash(branch_hash)
+        branch1 = Branch.from_hash(branch_hash)
+        branch2 = Branch.from_hash(branch_hash)
         assert(branch1 == branch2)
 
         branch1.remote_url = 'different_url'
@@ -126,12 +126,12 @@ module FlashFlow
       end
 
       def test_to_hash
-        branch1 = Base.from_hash(branch_hash)
+        branch1 = Branch.from_hash(branch_hash)
         assert_equal(branch1.to_hash, branch_hash)
       end
 
       def test_success
-        branch = Base.new(1,2,3)
+        branch = Branch.new(1,2,3)
 
         branch.success!
         assert(branch.success?)
@@ -141,7 +141,7 @@ module FlashFlow
       end
 
       def test_fail
-        branch = Base.new(1,2,3)
+        branch = Branch.new(1,2,3)
 
         branch.fail!
         assert(branch.fail?)
@@ -151,7 +151,7 @@ module FlashFlow
       end
 
       def test_removed
-        branch = Base.new(1,2,3)
+        branch = Branch.new(1,2,3)
 
         branch.removed!
         assert(branch.removed?)
@@ -161,7 +161,7 @@ module FlashFlow
       end
 
       def test_deleted
-        branch = Base.new(1,2,3)
+        branch = Branch.new(1,2,3)
 
         branch.deleted!
         assert(branch.deleted?)
@@ -171,7 +171,7 @@ module FlashFlow
       end
 
       def test_unknown
-        branch = Base.new(1,2,3)
+        branch = Branch.new(1,2,3)
 
         branch.unknown!
         assert(branch.unknown?)

--- a/test/lib/data/test_branch.rb
+++ b/test/lib/data/test_branch.rb
@@ -189,6 +189,7 @@ module FlashFlow
             'remote' => 'origin',
             'sha' => 'random_sha',
             'status' => 'success',
+            'resolutions' => {},
             'stories' => ['123'],
             'metadata' => {
                 'some' => 'data'

--- a/test/lib/data/test_collection.rb
+++ b/test/lib/data/test_collection.rb
@@ -64,41 +64,42 @@ module FlashFlow
       def test_reverse_merge_when_old_is_empty
         @collection.mark_success(@branch)
 
-        merged = @collection.reverse_merge({})
-        assert_equal(['the_origin_url/some_branch'], merged.keys)
-        assert(merged['the_origin_url/some_branch'].success?)
+        merged = @collection.reverse_merge(Collection.from_hash({}, {}))
+        assert_equal(['the_origin_url/some_branch'], merged.to_h.keys)
+        assert(merged.get('the_origin_url', 'some_branch').success?)
       end
 
       def test_reverse_merge_old_marks_old_branches
         @collection.mark_success(@branch)
 
-        merged = @collection.reverse_merge(old_branches)
-        assert(merged['the_origin_url/some_old_branch'].unknown?)
+        merged = @collection.reverse_merge(Collection.from_hash({}, old_branches))
+        assert(merged.get('the_origin_url', 'some_old_branch').unknown?)
       end
 
       def test_reverse_merge_old_adds_new_stories
         @collection.mark_success(@branch)
         @collection.add_story('origin', 'some_branch', '456')
-        merged = @collection.reverse_merge(old_branches)
+        merged = @collection.reverse_merge(Collection.from_hash({}, old_branches))
 
-        assert_equal(['222', '456'], merged['the_origin_url/some_branch'].stories)
+        assert_equal(['222', '456'], merged.get('the_origin_url', 'some_branch').stories)
       end
 
       def test_reverse_merge_old_uses_old_created_at
         @collection.add_to_merge('origin', 'some_old_branch')
         @collection.add_to_merge('origin', 'some_new_branch')
-        merged = @collection.reverse_merge(old_branches)
+        old_branch_collection = Collection.from_hash({}, old_branches)
+        merged = @collection.reverse_merge(old_branch_collection)
 
-        assert_equal(old_branches['the_origin_url/some_branch'].created_at, merged['the_origin_url/some_branch'].created_at)
+        assert_equal(old_branch_collection.get('the_origin_url', 'some_branch').created_at, merged.get('the_origin_url', 'some_branch').created_at)
         # Assert the new branch is created_at within the last minute
-        assert(merged['the_origin_url/some_new_branch'].created_at > (Time.now - 60))
+        assert(merged.get('the_origin_url', 'some_new_branch').created_at > (Time.now - 60))
       end
 
       def test_reverse_merge_old_uses_new_status
         @collection.mark_failure(old_branches['the_origin_url/some_branch'])
-        merged = @collection.reverse_merge(old_branches)
+        merged = @collection.reverse_merge(Collection.from_hash({}, old_branches))
 
-        assert(merged['the_origin_url/some_branch'].fail?)
+        assert(merged.get('the_origin_url', 'some_branch').fail?)
       end
 
       def test_fetch_returns_a_collection_instance

--- a/test/lib/data/test_collection.rb
+++ b/test/lib/data/test_collection.rb
@@ -17,20 +17,19 @@ module FlashFlow
 
       def setup
         setup_fake_branches
-        @fake_store = Minitest::Mock.new
         @fake_branches = FakeBranches.branches
         @branch = Branch.new('origin', 'the_origin_url', 'some_branch')
-        @collection = Collection.new({ 'origin' => 'the_origin_url' }, @fake_store, { 'class' => { 'name' => 'FakeBranches' }})
+        @collection = Collection.new({ 'origin' => 'the_origin_url' }, { 'class' => { 'name' => 'FakeBranches' }})
       end
 
       def test_from_hash_set_branches
         hash = { 'some_url/some_branch' => Branch.new('origin', 'the_origin_url', 'some_branch') }
-        assert_equal(Collection.from_hash({}, @fake_store, hash).branches, hash)
+        assert_equal(Collection.from_hash({}, hash).branches, hash)
       end
 
       def test_from_hash_set_remotes
         remotes = { 'some_remote' => 'some_remote_url' }
-        assert_equal(Collection.from_hash(remotes, @fake_store, {}).remotes, remotes)
+        assert_equal(Collection.from_hash(remotes, {}).remotes, remotes)
       end
 
       def test_fetch_calls_collection_class
@@ -40,11 +39,8 @@ module FlashFlow
         @fake_branches.verify
       end
 
-      def test_fetch_calls_store_if_no_collection_class
-        @fake_store.expect(:fetch, [], [])
-        @collection.fetch
-
-        @fake_store.verify
+      def test_fetch_returns_nil_if_no_collection_class
+        assert_nil(@collection.fetch)
       end
 
       def test_fetch_maps_collection_class_to_branches
@@ -65,16 +61,49 @@ module FlashFlow
         @fake_branches.verify
       end
 
-      def test_save!
+      def test_reverse_merge_when_old_is_empty
         @collection.mark_success(@branch)
-        @fake_store.expect(:merge_and_save, true, [@collection.branches])
 
-        @collection.save!
+        merged = @collection.reverse_merge({})
+        assert_equal(['the_origin_url/some_branch'], merged.keys)
+        assert(merged['the_origin_url/some_branch'].success?)
+      end
+
+      def test_reverse_merge_old_marks_old_branches
+        @collection.mark_success(@branch)
+
+        merged = @collection.reverse_merge(old_branches)
+        assert(merged['the_origin_url/some_old_branch'].unknown?)
+      end
+
+      def test_reverse_merge_old_adds_new_stories
+        @collection.mark_success(@branch)
+        @collection.add_story('origin', 'some_branch', '456')
+        merged = @collection.reverse_merge(old_branches)
+
+        assert_equal(['222', '456'], merged['the_origin_url/some_branch'].stories)
+      end
+
+      def test_reverse_merge_old_uses_old_created_at
+        @collection.add_to_merge('origin', 'some_old_branch')
+        @collection.add_to_merge('origin', 'some_new_branch')
+        merged = @collection.reverse_merge(old_branches)
+
+        assert_equal(old_branches['the_origin_url/some_branch'].created_at, merged['the_origin_url/some_branch'].created_at)
+        # Assert the new branch is created_at within the last minute
+        assert(merged['the_origin_url/some_new_branch'].created_at > (Time.now - 60))
+      end
+
+      def test_reverse_merge_old_uses_new_status
+        @collection.mark_failure(old_branches['the_origin_url/some_branch'])
+        merged = @collection.reverse_merge(old_branches)
+
+        assert(merged['the_origin_url/some_branch'].fail?)
       end
 
       def test_fetch_returns_a_collection_instance
         FakeBranches.branches.expect(:fetch, [])
-        collection = Collection.fetch({ 'origin' => 'the_origin_url' }, @fake_store, { 'class' => { 'name' => 'FakeBranches' }})
+        collection = Collection.fetch({ 'origin' => 'the_origin_url' }, { 'class' => { 'name' => 'FakeBranches' }})
         assert(collection.is_a?(Collection))
       end
 
@@ -195,6 +224,14 @@ module FlashFlow
         assert_equal(@collection.failures.values, [branch1, branch3])
       end
 
+      private
+
+      def old_branches
+        @old_branches ||= {
+            'the_origin_url/some_old_branch' => Branch.from_hash({'ref' => 'some_old_branch', 'remote_url' => 'the_origin_url', 'remote' => 'origin', 'created_at' => (Time.now - 3600), 'stories' => ['111']}),
+            'the_origin_url/some_branch' => Branch.from_hash({'ref' => 'some_branch', 'remote_url' => 'the_origin_url', 'remote' => 'origin', 'status' => 'success', 'created_at' => (Time.now - 1800), 'stories' => ['222']})
+        }
+      end
     end
   end
 end

--- a/test/lib/data/test_collection.rb
+++ b/test/lib/data/test_collection.rb
@@ -1,7 +1,7 @@
 require 'minitest_helper'
 
 module FlashFlow
-  module Branch
+  module Data
     class TestCollection < Minitest::Test
 
       def setup_fake_branches
@@ -19,12 +19,12 @@ module FlashFlow
         setup_fake_branches
         @fake_store = Minitest::Mock.new
         @fake_branches = FakeBranches.branches
-        @branch = Base.new('origin', 'the_origin_url', 'some_branch')
+        @branch = Branch.new('origin', 'the_origin_url', 'some_branch')
         @collection = Collection.new({ 'origin' => 'the_origin_url' }, @fake_store, { 'class' => { 'name' => 'FakeBranches' }})
       end
 
       def test_from_hash_set_branches
-        hash = { 'some_url/some_branch' => Base.new('origin', 'the_origin_url', 'some_branch') }
+        hash = { 'some_url/some_branch' => Branch.new('origin', 'the_origin_url', 'some_branch') }
         assert_equal(Collection.from_hash({}, @fake_store, hash).branches, hash)
       end
 
@@ -48,8 +48,8 @@ module FlashFlow
       end
 
       def test_fetch_maps_collection_class_to_branches
-        branch = Branch::Base.new('origin', 'the_origin_url', 'some_branch')
-        @fake_branches.expect(:fetch, [Base.from_hash({'remote' => branch.remote, 'remote_url' => branch.remote_url, 'ref' => branch.ref })], [])
+        branch = Data::Branch.new('origin', 'the_origin_url', 'some_branch')
+        @fake_branches.expect(:fetch, [Branch.from_hash({'remote' => branch.remote, 'remote_url' => branch.remote_url, 'ref' => branch.ref })], [])
         @collection.fetch
 
         assert_equal(@collection.branches.values, [branch])
@@ -57,8 +57,8 @@ module FlashFlow
       end
 
       def test_fetch_finds_the_remote
-        branch = Branch::Base.new('origin', 'the_origin_url', 'some_branch')
-        @fake_branches.expect(:fetch, [Base.from_hash({'remote_url' => branch.remote_url, 'ref' => branch.ref })], [])
+        branch = Data::Branch.new('origin', 'the_origin_url', 'some_branch')
+        @fake_branches.expect(:fetch, [Branch.from_hash({'remote_url' => branch.remote_url, 'ref' => branch.ref })], [])
         @collection.fetch
 
         assert_equal(@collection.branches.values, [branch])
@@ -185,9 +185,9 @@ module FlashFlow
       end
 
       def test_failures
-        branch1 = Base.new('111', '111', '111')
-        branch2 = Base.new('222', '222', '222')
-        branch3 = Base.new('333', '333', '333')
+        branch1 = Branch.new('111', '111', '111')
+        branch2 = Branch.new('222', '222', '222')
+        branch3 = Branch.new('333', '333', '333')
         @collection.mark_failure(branch1)
         @collection.mark_success(branch2)
         @collection.mark_failure(branch3)

--- a/test/lib/data/test_github.rb
+++ b/test/lib/data/test_github.rb
@@ -1,7 +1,7 @@
 require 'minitest_helper'
 
 module FlashFlow
-  module Branch
+  module Data
     class TestGithub < Minitest::Test
 
       class SomeFakeError < RuntimeError; end

--- a/test/lib/data/test_store.rb
+++ b/test/lib/data/test_store.rb
@@ -1,8 +1,8 @@
 require 'minitest_helper'
-require 'flash_flow/branch/store'
+require 'flash_flow/data/store'
 
 module FlashFlow
-  module Branch
+  module Data
     class TestBranchInfoStore < Minitest::Test
       def sample_branches
         {
@@ -15,7 +15,7 @@ module FlashFlow
         @mock_git = MockGit.new
         @mock_store = Minitest::Mock.new
         @collection = Collection.new({ 'origin' => 'the_origin_url' }, @mock_store)
-        @branch = Base.new('origin', 'the_origin_url', 'some_branch')
+        @branch = Branch.new('origin', 'the_origin_url', 'some_branch')
         @storage = Store.new('/dev/null', @mock_git)
       end
 
@@ -76,8 +76,8 @@ module FlashFlow
 
       def old_branches
         @old_branches ||= {
-            'the_origin_url/some_old_branch' => Base.from_hash({'ref' => 'some_old_branch', 'remote_url' => 'the_origin_url', 'remote' => 'origin', 'created_at' => (Time.now - 3600), 'stories' => ['111']}),
-            'the_origin_url/some_branch' => Base.from_hash({'ref' => 'some_branch', 'remote_url' => 'the_origin_url', 'remote' => 'origin', 'status' => 'success', 'created_at' => (Time.now - 1800), 'stories' => ['222']})
+            'the_origin_url/some_old_branch' => Branch.from_hash({'ref' => 'some_old_branch', 'remote_url' => 'the_origin_url', 'remote' => 'origin', 'created_at' => (Time.now - 3600), 'stories' => ['111']}),
+            'the_origin_url/some_branch' => Branch.from_hash({'ref' => 'some_branch', 'remote_url' => 'the_origin_url', 'remote' => 'origin', 'status' => 'success', 'created_at' => (Time.now - 1800), 'stories' => ['222']})
         }
       end
     end

--- a/test/lib/data/test_store.rb
+++ b/test/lib/data/test_store.rb
@@ -45,7 +45,7 @@ module FlashFlow
       def read_file_from_merge_branch; end
       def add_and_commit(_,_,_=nil); end
 
-      def in_merge_branch
+      def in_temp_merge_branch
         yield
       end
     end

--- a/test/lib/data/test_store.rb
+++ b/test/lib/data/test_store.rb
@@ -3,7 +3,7 @@ require 'flash_flow/data/store'
 
 module FlashFlow
   module Data
-    class TestBranchInfoStore < Minitest::Test
+    class TestStore < Minitest::Test
       def sample_branches
         {
             'origin/branch 1' => {'branch' => 'branch 1', 'remote' => 'origin', 'status' => 'success', 'stories' => ['123']},
@@ -13,50 +13,9 @@ module FlashFlow
 
       def setup
         @mock_git = MockGit.new
-        @mock_store = Minitest::Mock.new
-        @collection = Collection.new({ 'origin' => 'the_origin_url' }, @mock_store)
+        @collection = Collection.new({ 'origin' => 'the_origin_url' })
         @branch = Branch.new('origin', 'the_origin_url', 'some_branch')
         @storage = Store.new('/dev/null', @mock_git)
-      end
-
-      def test_merge_when_old_is_empty
-        @collection.mark_success(@branch)
-
-        merged = @storage.merge({}, @collection.branches)
-        assert_equal(['the_origin_url/some_branch'], merged.keys)
-        assert(merged['the_origin_url/some_branch'].success?)
-      end
-
-      def test_merge_old_marks_old_branches
-        @collection.mark_success(@branch)
-
-        merged = @storage.merge(old_branches, @collection.branches)
-        assert(merged['the_origin_url/some_old_branch'].unknown?)
-      end
-
-      def test_merge_old_adds_new_stories
-        @collection.mark_success(@branch)
-        @collection.add_story('origin', 'some_branch', '456')
-        merged = @storage.merge(old_branches, @collection.branches)
-
-        assert_equal(['222', '456'], merged['the_origin_url/some_branch'].stories)
-      end
-
-      def test_merge_old_uses_old_created_at
-        @collection.add_to_merge('origin', 'some_old_branch')
-        @collection.add_to_merge('origin', 'some_new_branch')
-        merged = @storage.merge(old_branches, @collection.branches)
-
-        assert_equal(old_branches['the_origin_url/some_branch'].created_at, merged['the_origin_url/some_branch'].created_at)
-        # Assert the new branch is created_at within the last minute
-        assert(merged['the_origin_url/some_new_branch'].created_at > (Time.now - 60))
-      end
-
-      def test_merge_old_uses_new_status
-        @collection.mark_failure(old_branches['the_origin_url/some_branch'])
-        merged = @storage.merge(old_branches, @collection.branches)
-
-        assert(merged['the_origin_url/some_branch'].fail?)
       end
 
       def test_get
@@ -76,8 +35,8 @@ module FlashFlow
 
       def old_branches
         @old_branches ||= {
-            'the_origin_url/some_old_branch' => Branch.from_hash({'ref' => 'some_old_branch', 'remote_url' => 'the_origin_url', 'remote' => 'origin', 'created_at' => (Time.now - 3600), 'stories' => ['111']}),
-            'the_origin_url/some_branch' => Branch.from_hash({'ref' => 'some_branch', 'remote_url' => 'the_origin_url', 'remote' => 'origin', 'status' => 'success', 'created_at' => (Time.now - 1800), 'stories' => ['222']})
+            'the_origin_url/some_old_branch' => {'ref' => 'some_old_branch', 'remote_url' => 'the_origin_url', 'remote' => 'origin', 'created_at' => (Time.now - 3600).to_s, 'stories' => ['111']},
+            'the_origin_url/some_branch' => {'ref' => 'some_branch', 'remote_url' => 'the_origin_url', 'remote' => 'origin', 'status' => 'success', 'created_at' => (Time.now - 1800).to_s, 'stories' => ['222']}
         }
       end
     end

--- a/test/lib/issue_tracker/test_pivotal.rb
+++ b/test/lib/issue_tracker/test_pivotal.rb
@@ -186,16 +186,16 @@ module FlashFlow
 
       def mock_git
         Minitest::Mock.new
-            .expect(:master_branch_contains?, true, [sample_branches.values[0].sha])
-            .expect(:master_branch_contains?, false, [sample_branches.values[1].sha])
-            .expect(:master_branch_contains?, false, [sample_branches.values[2].sha])
-            .expect(:master_branch_contains?, false, [sample_branches.values[3].sha])
-            .expect(:master_branch_contains?, false, [sample_branches.values[4].sha])
+            .expect(:master_branch_contains?, true, [sample_branches[0].sha])
+            .expect(:master_branch_contains?, false, [sample_branches[1].sha])
+            .expect(:master_branch_contains?, false, [sample_branches[2].sha])
+            .expect(:master_branch_contains?, false, [sample_branches[3].sha])
+            .expect(:master_branch_contains?, false, [sample_branches[4].sha])
       end
 
       def mock_working_branch(index)
         git = Minitest::Mock.new
-        5.times { git.expect(:working_branch, sample_branches.values[index].ref) }
+        5.times { git.expect(:working_branch, sample_branches[index].ref) }
         git
       end
 
@@ -209,13 +209,12 @@ module FlashFlow
       end
 
       def sample_branches
-        @sample_branches ||= {
-            'origin/branch1' => Data::Branch.from_hash({'ref' => 'branch1', 'remote' => 'origin', 'sha' => 'sha1', 'status' => 'success', 'created_at' => (Time.now - 3600), 'stories' => ['111']}),
-            'origin/branch2' => Data::Branch.from_hash({'ref' => 'branch2', 'remote' => 'origin', 'sha' => 'sha2', 'status' => 'success', 'created_at' => (Time.now - 1800), 'stories' => ['222']}),
-            'origin/branch3' => Data::Branch.from_hash({'ref' => 'branch3', 'remote' => 'origin', 'sha' => 'sha3', 'status' => 'fail', 'created_at' => (Time.now - 1800), 'stories' => ['333']}),
-            'origin/branch4' => Data::Branch.from_hash({'ref' => 'branch4', 'remote' => 'origin', 'sha' => 'sha4', 'status' => nil, 'created_at' => (Time.now - 1800), 'stories' => ['444']}),
-            'origin/branch5' => Data::Branch.from_hash({'ref' => 'branch5', 'remote' => 'origin', 'sha' => 'sha5', 'status' => 'removed', 'created_at' => (Time.now - 1800), 'stories' => ['555']})
-        }
+        @sample_branches ||= [Data::Branch.from_hash({'ref' => 'branch1', 'remote' => 'origin', 'sha' => 'sha1', 'status' => 'success', 'created_at' => (Time.now - 3600), 'stories' => ['111']}),
+            Data::Branch.from_hash({'ref' => 'branch2', 'remote' => 'origin', 'sha' => 'sha2', 'status' => 'success', 'created_at' => (Time.now - 1800), 'stories' => ['222']}),
+            Data::Branch.from_hash({'ref' => 'branch3', 'remote' => 'origin', 'sha' => 'sha3', 'status' => 'fail', 'created_at' => (Time.now - 1800), 'stories' => ['333']}),
+            Data::Branch.from_hash({'ref' => 'branch4', 'remote' => 'origin', 'sha' => 'sha4', 'status' => nil, 'created_at' => (Time.now - 1800), 'stories' => ['444']}),
+            Data::Branch.from_hash({'ref' => 'branch5', 'remote' => 'origin', 'sha' => 'sha5', 'status' => 'removed', 'created_at' => (Time.now - 1800), 'stories' => ['555']})
+        ]
       end
     end
   end

--- a/test/lib/issue_tracker/test_pivotal.rb
+++ b/test/lib/issue_tracker/test_pivotal.rb
@@ -210,11 +210,11 @@ module FlashFlow
 
       def sample_branches
         @sample_branches ||= {
-            'origin/branch1' => Branch::Base.from_hash({'ref' => 'branch1', 'remote' => 'origin', 'sha' => 'sha1', 'status' => 'success', 'created_at' => (Time.now - 3600), 'stories' => ['111']}),
-            'origin/branch2' => Branch::Base.from_hash({'ref' => 'branch2', 'remote' => 'origin', 'sha' => 'sha2', 'status' => 'success', 'created_at' => (Time.now - 1800), 'stories' => ['222']}),
-            'origin/branch3' => Branch::Base.from_hash({'ref' => 'branch3', 'remote' => 'origin', 'sha' => 'sha3', 'status' => 'fail', 'created_at' => (Time.now - 1800), 'stories' => ['333']}),
-            'origin/branch4' => Branch::Base.from_hash({'ref' => 'branch4', 'remote' => 'origin', 'sha' => 'sha4', 'status' => nil, 'created_at' => (Time.now - 1800), 'stories' => ['444']}),
-            'origin/branch5' => Branch::Base.from_hash({'ref' => 'branch5', 'remote' => 'origin', 'sha' => 'sha5', 'status' => 'removed', 'created_at' => (Time.now - 1800), 'stories' => ['555']})
+            'origin/branch1' => Data::Branch.from_hash({'ref' => 'branch1', 'remote' => 'origin', 'sha' => 'sha1', 'status' => 'success', 'created_at' => (Time.now - 3600), 'stories' => ['111']}),
+            'origin/branch2' => Data::Branch.from_hash({'ref' => 'branch2', 'remote' => 'origin', 'sha' => 'sha2', 'status' => 'success', 'created_at' => (Time.now - 1800), 'stories' => ['222']}),
+            'origin/branch3' => Data::Branch.from_hash({'ref' => 'branch3', 'remote' => 'origin', 'sha' => 'sha3', 'status' => 'fail', 'created_at' => (Time.now - 1800), 'stories' => ['333']}),
+            'origin/branch4' => Data::Branch.from_hash({'ref' => 'branch4', 'remote' => 'origin', 'sha' => 'sha4', 'status' => nil, 'created_at' => (Time.now - 1800), 'stories' => ['444']}),
+            'origin/branch5' => Data::Branch.from_hash({'ref' => 'branch5', 'remote' => 'origin', 'sha' => 'sha5', 'status' => 'removed', 'created_at' => (Time.now - 1800), 'stories' => ['555']})
         }
       end
     end

--- a/test/lib/test_branch_merger.rb
+++ b/test/lib/test_branch_merger.rb
@@ -62,7 +62,7 @@ module FlashFlow
     end
 
     def branch
-      @branch ||= Branch::Base.from_hash({'ref' => 'pushing_branch', 'remote' => 'origin', 'status' => 'fail', 'stories' => []})
+      @branch ||= Data::Branch.from_hash({'ref' => 'pushing_branch', 'remote' => 'origin', 'status' => 'fail', 'stories' => []})
     end
 
     def git

--- a/test/lib/test_deploy.rb
+++ b/test/lib/test_deploy.rb
@@ -93,8 +93,12 @@ module FlashFlow
 
     def test_successful_merge
       collection.expect(:mark_success, true, [@branch])
+      collection.expect(:set_resolutions, true, [ @branch, { 'filename' => ["resolution_sha"] } ])
 
-      merger.expect(:do_merge, :success, [ false ]).expect(:sha, 'sha')
+      merger.
+          expect(:do_merge, :success, [ false ]).
+          expect(:sha, 'sha').
+          expect(:resolutions, { 'filename' => ["resolution_sha"] })
 
       BranchMerger.stub(:new, merger) do
         @deploy.git_merge(@branch, false)

--- a/test/lib/test_deploy.rb
+++ b/test/lib/test_deploy.rb
@@ -29,7 +29,7 @@ module FlashFlow
       collection.expect(:failures, {'origin/pushing_branch' => @branch})
       @branch.fail!('some_random_sha')
 
-      @deploy.instance_variable_set('@branches'.to_sym, collection)
+      @deploy.instance_variable_set('@data'.to_sym, collection)
 
       current_branch_error = "\nERROR: Your branch did not merge to test_acceptance. Run the following commands to fix the merge conflict and then re-run this script:\n\n  git checkout some_random_sha\n  git merge pushing_branch\n  # Resolve the conflicts\n  git add <conflicted files>\n  git commit --no-edit"
 
@@ -42,7 +42,7 @@ module FlashFlow
       collection = Minitest::Mock.new
       collection.expect(:failures, {'origin/pushing_branch' => @branch})
 
-      @deploy.instance_variable_set('@branches'.to_sym, collection)
+      @deploy.instance_variable_set('@data'.to_sym, collection)
 
       other_branch_error = "WARNING: Unable to merge branch origin/pushing_branch to test_acceptance due to conflicts."
 
@@ -130,7 +130,7 @@ module FlashFlow
       return @collection if @collection
 
       @collection = Minitest::Mock.new
-      @deploy.instance_variable_set('@branches'.to_sym, @collection)
+      @deploy.instance_variable_set('@data'.to_sym, @collection)
     end
 
   end

--- a/test/lib/test_deploy.rb
+++ b/test/lib/test_deploy.rb
@@ -14,7 +14,7 @@ module FlashFlow
                   'use_rerere' => true
               })
 
-      @branch = Branch::Base.from_hash({'ref' => 'pushing_branch', 'remote' => 'origin', 'status' => 'fail', 'stories' => []})
+      @branch = Data::Branch.from_hash({'ref' => 'pushing_branch', 'remote' => 'origin', 'status' => 'fail', 'stories' => []})
       @deploy = Deploy.new
     end
 

--- a/test/lib/test_git.rb
+++ b/test/lib/test_git.rb
@@ -30,18 +30,20 @@ module FlashFlow
 
     def test_commit_rerere_checks_flag
       @git_args['use_rerere'] = false
-      instance.commit_rerere
+      instance.commit_rerere([])
 
       @cmd_runner.verify
     end
 
     def test_commit_rerere_runs_commands
       @cmd_runner.expect(:run, true, ['mkdir rr-cache'])
-      @cmd_runner.expect(:run, true, ['cp -R .git/rr-cache/* rr-cache/'])
+      @cmd_runner.expect(:run, true, ['rm -rf rr-cache/*'])
+      @cmd_runner.expect(:run, true, ['cp -R .git/rr-cache/xyz rr-cache/'])
+      @cmd_runner.expect(:run, true, ['cp -R .git/rr-cache/abc rr-cache/'])
       @cmd_runner.expect(:run, true, ['git add rr-cache/'])
       @cmd_runner.expect(:run, true, ["git commit -m 'Update rr-cache'"])
 
-      instance.commit_rerere
+      instance.commit_rerere(['xyz', 'abc'])
       @cmd_runner.verify
     end
 


### PR DESCRIPTION
Change structure of the metadata file.
Reduce the number of rerere resolutions to only be for branches that are not merged to master and that have been merged to acceptance at least once in the last two weeks. Two weeks is an arbitrary cutoff for getting rid of resolutions for branches that were closed or otherwise not merged for a period of time.
