### PR TITLE
Remove git force push option because of local git consistency problem

### DIFF
--- a/lib/flash_flow/merge/acceptance.rb
+++ b/lib/flash_flow/merge/acceptance.rb
@@ -41,9 +41,10 @@ module FlashFlow
 
             @git.copy_temp_to_branch(@git.merge_branch, commit_message)
             @git.delete_temp_merge_branch
-            @git.push(@git.merge_branch, true)
+            @git.push(@git.merge_branch)
           end
 
+          raise OutOfSyncWithRemote.new("#{@git.merge_branch} is out of sync with the remote.") unless @git.last_success?
           print_errors
           logger.info "### Finished #{@local_git.merge_branch} merge ###"
         rescue Lock::Error, OutOfSyncWithRemote => e


### PR DESCRIPTION
Different versions of local git can cause in-app git state problem
that is hard to reason about.
